### PR TITLE
Update RNDatePickerComponentPackage.java

### DIFF
--- a/android/src/main/java/com/bitup/datepickercomponent/RNDatePickerComponentPackage.java
+++ b/android/src/main/java/com/bitup/datepickercomponent/RNDatePickerComponentPackage.java
@@ -16,11 +16,6 @@ public class RNDatePickerComponentPackage implements ReactPackage {
       return Collections.emptyList();
     }
 
-    // Depreciated RN >= 0.47.0
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Arrays.<ViewManager>asList(new RNDatePickerComponentViewManager());


### PR DESCRIPTION
Automatic installation is failing in >0.47 so removed this line.

With this line intact, we get error on `react-native run-android`:

> :react-native-date-picker-component-android:compileReleaseJavaWithJavac - is not incremental (e.g. outputs have changed, no previous execution, etc.).
C:\Users\Mercurius\Documents\GitHub\PetFolk-Mobile\node_modules\react-native-date-picker-component-android\android\src\main\java\com\bitup\datepickercomponent\RNDatePickerComponentPackage.java:19: error: method does not override or implement a method from a supertype
    @Override
    ^
1 error
:react-native-date-picker-component-android:compileReleaseJavaWithJavac FAILED



Related to this - https://github.com/facebook/react-native/releases/tag/v0.47.2

Remove unused createJSModules calls ([ce6fb33](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8), [53d5504](https://github.com/facebook/react-native/commit/53d5504f4077bf7fb7cbf7c1edac7e2cbde5c964))